### PR TITLE
[ Feat ] Windows Support

### DIFF
--- a/.github/workflows/larastan.yml
+++ b/.github/workflows/larastan.yml
@@ -9,7 +9,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - "8.2"
-    name: php ${{ matrix.php-version }} on ${{ matrix.operating-system }}
+    name: Larastan ${{ matrix.php-version }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.github/workflows/larastan.yml
+++ b/.github/workflows/larastan.yml
@@ -9,7 +9,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - "8.2"
-    name: Larastan ${{ matrix.php-version }} on ${{ matrix.operating-system }}
+    name: php ${{ matrix.php-version }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -12,7 +12,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - "8.2"
-    name: Pint ${{ matrix.php-version }} on ${{ matrix.operating-system }}
+    name: php ${{ matrix.php-version }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -3,10 +3,17 @@ on:
   workflow_dispatch:
   push:
     branches-ignore:
-      - 'dependabot/npm_and_yarn/*'
+      - "dependabot/npm_and_yarn/*"
 jobs:
   phplint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operating-system:
+          - ubuntu-latest
+        php-version:
+          - "8.2"
+    name: Pint ${{ matrix.php-version }} on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         php-version:
           - "8.1"
           - "8.2"
-    name: Tests ${{ matrix.php-version }} on ${{ matrix.operating-system }}
+    name: php ${{ matrix.php-version }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,11 @@ jobs:
       matrix:
         operating-system:
           - ubuntu-latest
+          - windows-latest
         php-version:
           - "8.1"
           - "8.2"
-    name: php ${{ matrix.php-version }} on ${{ matrix.operating-system }}
+    name: Tests ${{ matrix.php-version }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/tests/Feature/InstallTest.php
+++ b/tests/Feature/InstallTest.php
@@ -11,7 +11,7 @@ it('has an install command', function () {
 it('fails if git is not initialized', function () {
     File::shouldReceive('exists')
         ->once()
-        ->with(base_path('.git'))
+        ->with(normalizePath(base_path('.git')))
         ->andReturnFalse();
 
     $this->artisan('install')

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -5,12 +5,12 @@ use Illuminate\Support\Facades\File;
 it('deletes skip-once file if exists and outputs nothing', function () {
     File::shouldReceive('exists')
         ->once()
-        ->with(base_path('bin/skip-once'))
+        ->with(normalizePath(base_path('bin/skip-once')))
         ->andReturnTrue();
 
     File::shouldReceive('delete')
         ->once()
-        ->with(base_path('bin/skip-once'))
+        ->with(normalizePath(base_path('bin/skip-once')))
         ->andReturnTrue();
 
     $this->artisan('get-run-cmd pre-commit')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,3 +43,17 @@ function something(): void
 {
     // ..
 }
+
+function normalizePath($path): string
+{
+    if (isWindows()) {
+        return str_replace('\\', '/', $path);
+    }
+
+    return $path;
+}
+
+function isWindows(): bool
+{
+    return str_starts_with(strtoupper(PHP_OS), 'WIN');
+}


### PR DESCRIPTION
Resolves #14

# Step to reproduce

```bash
# current folder: c:\Users\gibarra\develop
# clone repo
git clone https://github.com/ProjektGopher/whisky.git
cd whisky
# install dependences
composer install

# install hook of this repo (linter-pint, stan and test)
php whisky install -n

# check files create
# ls ./.git/hooks
dir .\.git\hooks

# here, files was created

# check content
# cat ./.git/hooks/pre-commit
type .\.git\hooks\pre-commit

# here is the problem, this file use "\" instead of "/" and in windows this is a problem because not escape the character
# the solution is change "\" to "/" (or "\\" to "\") in the files

#####
# confirm error by running pre-commit hook 
git hook run pre-commit
# error
# .git/hooks/pre-commit: line 2: C:Usersgibarradevelopwhiskywhisky: command not found

```

# Changes in files generated

File: .\.git\hooks\pre-commit

```diff
#!/bin/sh
- eval "$(C:\Users\gibarra\develop\whisky\whisky get-run-cmd pre-push)"
+ eval "$(C:/Users/gibarra/develop/whisky/whisky get-run-cmd pre-push)"

```
