### PR TITLE
[ Task ] Suggest Install as Dev Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "projektgopher/whisky",
     "description": "A simple CLI tool for managing a project's git hooks across multiple members.",
     "keywords": [
+        "dev",
         "git",
         "hooks",
         "cli",


### PR DESCRIPTION
By adding the `dev` keyword to `composer.json` composer will prompt the user to install as a dev dependency instead of a regular one.