### PR TITLE
[ Feat ] Pass optional arguments to hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ For a complete list of supported git hooks, see the [Git Documentation](https://
 
 Adding or removing any **hooks** (_not_ individual commands) to your `whisky.json` file should be followed by `./vendor/bin/whisky update` to ensure that these changes are reflected in your `.git/hooks` directory.
 
+### Working With Hook Arguments
+Some hooks in git are passed arguments.
+
+The `commit-msg` hook is a perfect example. It's passed the path to git's temporary file containing the commit message,
+which can then be used by scripts like npm's [commitlint](https://commitlint.js.org/) to allow or prevent commit
+messages that might not conform to your project's standards.
+
+To use this argument that git passes, you can _optionally_ include `$1` in your array of commands.
+(You should wrap it in escaped double quotes to prevent odd behavior due to whitespace)
+
+```js
+// whisky.json
+// ...
+  "commit-msg": [
+    "npx --no -- commitlint --edit \"$1\""
+  ]
+// ...
+```
+
+> [!IMPORTANT]  
+> For `commitlint` specifically, you'll need to follow the instructions in their
+> [documentation](https://commitlint.js.org/guides/getting-started.html),
+> as it will require extra packages and setup to run in your project.
+
 ### Automating Hook Updates
 While we suggest leaving Whisky as an 'opt-in' tool, by adding a couple of Composer scripts we can _ensure_ consistent git hooks for all project contributors. This will **force** everyone on the project to use Whisky:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ The `install` command will create a `whisky.json` file in your project root:
 
 For a complete list of supported git hooks, see the [Git Documentation](https://git-scm.com/docs/githooks#_hooks).
 
-> **Warning** all hooks are **evaluated as-is** in the terminal. Keep this in mind when committing anything involving changes to your `whisky.json`.
+> [!CAUTION]
+> all hooks are **evaluated as-is** in the terminal. Keep this in mind when committing anything involving changes to your `whisky.json`.
 
 Adding or removing any **hooks** (_not_ individual commands) to your `whisky.json` file should be followed by `./vendor/bin/whisky update` to ensure that these changes are reflected in your `.git/hooks` directory.
 
@@ -93,7 +94,8 @@ In this case, running the following command will have the exact same effect.
 ./vendor/bin/whisky skip-once
 ``` 
 
-> **Note** by adding `alias whisky=./vendor/bin/whisky` to your `bash.rc` file, you can shorten the length of this command.
+> [!TIP] 
+> by adding `alias whisky=./vendor/bin/whisky` to your `bash.rc` file, you can shorten the length of this command.
 
 ### Disabling Hooks
 Adding a hook's name to the `disabled` array in your `whisky.json` will disable the hook from running.
@@ -115,7 +117,8 @@ you to run scripts written in _any_ language.
 // ...
 ```
 
-> **Note** When doing this, make sure any scripts referenced are **executable**:
+> [!NOTE] 
+> When doing this, make sure any scripts referenced are **executable**:
 ```bash
 chmod +x ./scripts/*
 ```
@@ -142,7 +145,8 @@ whisky uninstall -n
 
 
 ## Contributing
-> **Note** Don't build the binary when contributing. The binary will be built when a release is tagged.
+> [!NOTE] 
+> Don't build the binary when contributing. The binary will be built when a release is tagged.
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for more details.
 

--- a/app/Commands/Run.php
+++ b/app/Commands/Run.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Process as SymfonyProcess;
 
 class Run extends Command
 {
-    protected $signature = 'run {hook}';
+    protected $signature = 'run {hook} {argument?}';
 
     protected $description = 'Run the scripts for a given hook';
 
@@ -41,6 +41,8 @@ class Run extends Command
         Hook::make($this->argument('hook'))
             ->getScripts()
             ->each(function (string $script) use (&$exitCode): void {
+                $script = str_replace('$1', $this->argument('argument'), $script);
+
                 $isTtySupported = SymfonyProcess::isTtySupported();
 
                 $result = $isTtySupported

--- a/app/Commands/Run.php
+++ b/app/Commands/Run.php
@@ -41,7 +41,11 @@ class Run extends Command
         Hook::make($this->argument('hook'))
             ->getScripts()
             ->each(function (string $script) use (&$exitCode): void {
-                $script = str_replace('$1', $this->argument('argument'), $script);
+                $script = str_replace(
+                    search: '$1',
+                    replace: trim($this->argument('argument'), '"'),
+                    subject: $script,
+                );
 
                 $isTtySupported = SymfonyProcess::isTtySupported();
 

--- a/app/Hook.php
+++ b/app/Hook.php
@@ -140,8 +140,9 @@ class Hook
     public function getSnippets(): Collection
     {
         return collect([
-            "{$this->bin} run {$this->hook}",
+            "{$this->bin} run {$this->hook} \"$1\"",
             // Legacy Snippets.
+            "{$this->bin} run {$this->hook}",
             "eval \"$({$this->bin} get-run-cmd {$this->hook})\"",
             "eval \"$(./vendor/bin/whisky get-run-cmd {$this->hook})\"",
         ]);

--- a/app/Platform.php
+++ b/app/Platform.php
@@ -15,6 +15,15 @@ class Platform
         return static::normalizePath(getcwd());
     }
 
+    public static function temp_test_path(string $path = ''): string
+    {
+        if ($path) {
+            return static::cwd("tests/tmp/{$path}");
+        }
+
+        return static::cwd('tests/tmp');
+    }
+
     public static function normalizePath(string $path): string
     {
         if ((new self)->isWindows()) {

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -142,7 +142,7 @@ it('handles a missing expected argument gracefully', function () {
     expect(file_get_contents($tmp_file))
         ->toBe((new Platform)->isNotWindows()
             ? PHP_EOL
-            : '""\r\n'
+            : "\"\"\r\n"
         );
 
     unlink($tmp_file);

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -76,7 +76,7 @@ it('accepts an optional argument and the argument is correct', function () {
     expect(file_get_contents($tmp_file))
         ->toBe((new Platform)->isNotWindows()
             ? '.git/COMMIT_EDITMSG'.PHP_EOL
-            : '".git/COMMIT_EDITMSG"'.PHP_EOL
+            : '".git/COMMIT_EDITMSG"'
         );
 
     unlink($tmp_file);
@@ -142,7 +142,7 @@ it('handles a missing expected argument gracefully', function () {
     expect(file_get_contents($tmp_file))
         ->toBe((new Platform)->isNotWindows()
             ? PHP_EOL
-            : '""'.PHP_EOL
+            : '""'
         );
 
     unlink($tmp_file);

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -74,10 +74,7 @@ it('accepts an optional argument and the argument is correct', function () {
         ->assertExitCode(0);
 
     expect(file_get_contents($tmp_file))
-        ->toBe((new Platform)->isNotWindows()
-            ? '.git/COMMIT_EDITMSG'.PHP_EOL
-            : '".git/COMMIT_EDITMSG"'.PHP_EOL
-        );
+        ->toContain('.git/COMMIT_EDITMSG');
 
     unlink($tmp_file);
 });
@@ -139,11 +136,8 @@ it('handles a missing expected argument gracefully', function () {
     $this->artisan('run commit-msg')
         ->assertExitCode(0);
 
-    expect(file_get_contents($tmp_file))
-        ->toBe((new Platform)->isNotWindows()
-            ? PHP_EOL
-            : "\"\"\r\n"
-        );
+    expect(file_exists($tmp_file))
+        ->toBeTrue();
 
     unlink($tmp_file);
 });

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -137,7 +137,7 @@ it('handles a missing expected argument gracefully', function () {
         ->assertExitCode(0);
 
     expect(file_get_contents($tmp_file))
-        ->toBe("\n");
+        ->toBe(PHP_EOL);
 
     unlink($tmp_file);
 });

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -76,7 +76,7 @@ it('accepts an optional argument and the argument is correct', function () {
     expect(file_get_contents($tmp_file))
         ->toBe((new Platform)->isNotWindows()
             ? '.git/COMMIT_EDITMSG'.PHP_EOL
-            : '".git/COMMIT_EDITMSG"'
+            : '".git/COMMIT_EDITMSG"'.PHP_EOL
         );
 
     unlink($tmp_file);
@@ -142,7 +142,7 @@ it('handles a missing expected argument gracefully', function () {
     expect(file_get_contents($tmp_file))
         ->toBe((new Platform)->isNotWindows()
             ? PHP_EOL
-            : '""'
+            : '""\r\n'
         );
 
     unlink($tmp_file);

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -74,7 +74,7 @@ it('accepts an optional argument and the argument is correct', function () {
         ->assertExitCode(0);
 
     expect(file_get_contents($tmp_file))
-        ->toContain('.git/COMMIT_EDITMSG');
+        ->toBe('.git/COMMIT_EDITMSG'.PHP_EOL);
 
     unlink($tmp_file);
 });

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\File;
 use ProjektGopher\Whisky\Platform;
 
-it('deletes skip-once file if exists as long as whisky.json exists', function () {
+it('deletes skip-once file if exists as long as whisky.json exists and does not run the hook', function () {
     File::shouldReceive('missing')
         ->once()
         ->with(Platform::cwd('whisky.json'))
@@ -19,7 +19,115 @@ it('deletes skip-once file if exists as long as whisky.json exists', function ()
         ->with(Platform::cwd('.git/hooks/skip-once'))
         ->andReturnTrue();
 
+    File::shouldReceive('get')
+        ->with(Platform::cwd('whisky.json'))
+        ->andReturn(<<<'JSON'
+        {
+            "disabled": [],
+            "hooks": {
+                "pre-commit": [
+                    "echo \"poop\" > /tmp/whisky_test_commit_msg"
+                ]
+            }
+        }
+        JSON);
+
     $this->artisan('run pre-commit')
-        ->doesntExpectOutputToContain('run-hook')
         ->assertExitCode(0);
-})->skip('Needs to be refactored so that the hooks don\'t actually run');
+
+    expect(file_exists('/tmp/whisky_test_commit_msg'))
+        ->toBeFalse();
+});
+
+it('accepts an optional argument and the argument is correct', function () {
+    File::shouldReceive('missing')
+        ->with(Platform::cwd('whisky.json'))
+        ->andReturnFalse();
+
+    File::shouldReceive('exists')
+        ->with(Platform::cwd('.git/hooks/skip-once'))
+        ->andReturnFalse();
+
+    /**
+     * We need to send the output to the disk
+     * otherwise the output is sent to the
+     * test output and we can't check it.
+     */
+    File::shouldReceive('get')
+        ->with(Platform::cwd('whisky.json'))
+        ->andReturn(<<<'JSON'
+        {
+            "disabled": [],
+            "hooks": {
+                "commit-msg": [
+                    "echo \"$1\" > /tmp/whisky_test_commit_msg"
+                ]
+            }
+        }
+        JSON);
+
+    $this->artisan('run commit-msg ".git/COMMIT_EDITMSG"')
+        ->assertExitCode(0);
+
+    expect(file_get_contents('/tmp/whisky_test_commit_msg'))
+        ->toContain('.git/COMMIT_EDITMSG');
+
+    unlink('/tmp/whisky_test_commit_msg');
+});
+
+it('still works if no arguments are passed to run command', function () {
+    File::shouldReceive('missing')
+        ->with(Platform::cwd('whisky.json'))
+        ->andReturnFalse();
+
+    File::shouldReceive('exists')
+        ->with(Platform::cwd('.git/hooks/skip-once'))
+        ->andReturnFalse();
+
+    File::shouldReceive('get')
+        ->with(Platform::cwd('whisky.json'))
+        ->andReturn(<<<'JSON'
+        {
+            "disabled": [],
+            "hooks": {
+                "pre-commit": [
+                    "echo \"pre-commit\" > /dev/null"
+                ]
+            }
+        }
+        JSON);
+
+    $this->artisan('run pre-commit')
+        ->assertExitCode(0);
+});
+
+it('handles a missing expected argument gracefully', function () {
+    File::shouldReceive('missing')
+        ->with(Platform::cwd('whisky.json'))
+        ->andReturnFalse();
+
+    File::shouldReceive('exists')
+        ->with(Platform::cwd('.git/hooks/skip-once'))
+        ->andReturnFalse();
+
+    File::shouldReceive('get')
+        ->with(Platform::cwd('whisky.json'))
+        ->andReturn(<<<'JSON'
+        {
+            "disabled": [],
+            "hooks": {
+                "commit-msg": [
+                    "echo \"$1\" > /tmp/whisky_test_commit_msg"
+                ]
+            }
+        }
+        JSON);
+
+    $this->artisan('run commit-msg')
+        ->assertExitCode(0);
+
+    expect(file_get_contents('/tmp/whisky_test_commit_msg'))
+        ->toBe("\n");
+
+    unlink('/tmp/whisky_test_commit_msg');
+});

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -19,14 +19,16 @@ it('deletes skip-once file if exists as long as whisky.json exists and does not 
         ->with(Platform::cwd('.git/hooks/skip-once'))
         ->andReturnTrue();
 
+    $tmp_file = Platform::temp_test_path('whisky_test_commit_msg');
+
     File::shouldReceive('get')
         ->with(Platform::cwd('whisky.json'))
-        ->andReturn(<<<'JSON'
+        ->andReturn(<<<"JSON"
         {
             "disabled": [],
             "hooks": {
                 "pre-commit": [
-                    "echo \"poop\" > /tmp/whisky_test_commit_msg"
+                    "echo \"poop\" > {$tmp_file}"
                 ]
             }
         }
@@ -35,7 +37,7 @@ it('deletes skip-once file if exists as long as whisky.json exists and does not 
     $this->artisan('run pre-commit')
         ->assertExitCode(0);
 
-    expect(file_exists('/tmp/whisky_test_commit_msg'))
+    expect(file_exists($tmp_file))
         ->toBeFalse();
 });
 
@@ -48,6 +50,8 @@ it('accepts an optional argument and the argument is correct', function () {
         ->with(Platform::cwd('.git/hooks/skip-once'))
         ->andReturnFalse();
 
+    $tmp_file = Platform::temp_test_path('whisky_test_commit_msg');
+
     /**
      * We need to send the output to the disk
      * otherwise the output is sent to the
@@ -55,12 +59,12 @@ it('accepts an optional argument and the argument is correct', function () {
      */
     File::shouldReceive('get')
         ->with(Platform::cwd('whisky.json'))
-        ->andReturn(<<<'JSON'
+        ->andReturn(<<<"JSON"
         {
             "disabled": [],
             "hooks": {
                 "commit-msg": [
-                    "echo \"$1\" > /tmp/whisky_test_commit_msg"
+                    "echo \"$1\" > {$tmp_file}"
                 ]
             }
         }
@@ -69,10 +73,10 @@ it('accepts an optional argument and the argument is correct', function () {
     $this->artisan('run commit-msg ".git/COMMIT_EDITMSG"')
         ->assertExitCode(0);
 
-    expect(file_get_contents('/tmp/whisky_test_commit_msg'))
+    expect(file_get_contents($tmp_file))
         ->toContain('.git/COMMIT_EDITMSG');
 
-    unlink('/tmp/whisky_test_commit_msg');
+    unlink($tmp_file);
 });
 
 it('still works if no arguments are passed to run command', function () {
@@ -84,14 +88,16 @@ it('still works if no arguments are passed to run command', function () {
         ->with(Platform::cwd('.git/hooks/skip-once'))
         ->andReturnFalse();
 
+    $tmp_file = Platform::temp_test_path('whisky_test_pre_commit');
+
     File::shouldReceive('get')
         ->with(Platform::cwd('whisky.json'))
-        ->andReturn(<<<'JSON'
+        ->andReturn(<<<"JSON"
         {
             "disabled": [],
             "hooks": {
                 "pre-commit": [
-                    "echo \"pre-commit\" > /dev/null"
+                    "echo \"pre-commit\" > {$tmp_file}"
                 ]
             }
         }
@@ -99,6 +105,8 @@ it('still works if no arguments are passed to run command', function () {
 
     $this->artisan('run pre-commit')
         ->assertExitCode(0);
+
+    unlink($tmp_file);
 });
 
 it('handles a missing expected argument gracefully', function () {
@@ -110,14 +118,16 @@ it('handles a missing expected argument gracefully', function () {
         ->with(Platform::cwd('.git/hooks/skip-once'))
         ->andReturnFalse();
 
+    $tmp_file = Platform::temp_test_path('whisky_test_commit_msg');
+
     File::shouldReceive('get')
         ->with(Platform::cwd('whisky.json'))
-        ->andReturn(<<<'JSON'
+        ->andReturn(<<<"JSON"
         {
             "disabled": [],
             "hooks": {
                 "commit-msg": [
-                    "echo \"$1\" > /tmp/whisky_test_commit_msg"
+                    "echo \"$1\" > {$tmp_file}"
                 ]
             }
         }
@@ -126,8 +136,8 @@ it('handles a missing expected argument gracefully', function () {
     $this->artisan('run commit-msg')
         ->assertExitCode(0);
 
-    expect(file_get_contents('/tmp/whisky_test_commit_msg'))
+    expect(file_get_contents($tmp_file))
         ->toBe("\n");
 
-    unlink('/tmp/whisky_test_commit_msg');
+    unlink($tmp_file);
 });

--- a/tests/Feature/RunTest.php
+++ b/tests/Feature/RunTest.php
@@ -74,7 +74,10 @@ it('accepts an optional argument and the argument is correct', function () {
         ->assertExitCode(0);
 
     expect(file_get_contents($tmp_file))
-        ->toBe('.git/COMMIT_EDITMSG'.PHP_EOL);
+        ->toBe((new Platform)->isNotWindows()
+            ? '.git/COMMIT_EDITMSG'.PHP_EOL
+            : '".git/COMMIT_EDITMSG"'.PHP_EOL
+        );
 
     unlink($tmp_file);
 });
@@ -137,7 +140,10 @@ it('handles a missing expected argument gracefully', function () {
         ->assertExitCode(0);
 
     expect(file_get_contents($tmp_file))
-        ->toBe(PHP_EOL);
+        ->toBe((new Platform)->isNotWindows()
+            ? PHP_EOL
+            : '""'.PHP_EOL
+        );
 
     unlink($tmp_file);
 });

--- a/tests/tmp/.gitignore
+++ b/tests/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/whisky.json
+++ b/whisky.json
@@ -1,6 +1,11 @@
 {
-    "disabled": [],
+    "disabled": [
+        "commit-msg"
+    ],
     "hooks": {
+        "commit-msg": [
+            "echo \"$1\""
+        ],
         "pre-commit": [
             "composer lint -- --test"
         ],

--- a/whisky.json
+++ b/whisky.json
@@ -1,11 +1,6 @@
 {
-    "disabled": [
-        "commit-msg"
-    ],
+    "disabled": [],
     "hooks": {
-        "commit-msg": [
-            "echo \"$1\""
-        ],
         "pre-commit": [
             "composer lint -- --test"
         ],


### PR DESCRIPTION
Resolves #64

Some hooks in git are passed arguments for further analysis.

The `commit-msg` is one example of that. It's passed the path to the file containing the commit message.

This file can be used by scripts like npm's `commitlint` to allow or block messages that might not conform to the org's standards.

This should allow the following config:
```js
{
    "hooks": {
        "commit-msg": [
            "npx --no -- commitlint --edit \"$1\""
        ]
    }
}
```

### Tasks
- [x] Add tests
- [x] Add documentation, including instructions to follow the docs for commitlint explicitly
- [x] Move Bugfix to separate PR (hooks added by the `Update` command were not made executable)
